### PR TITLE
Updated functionality to write events into the stream

### DIFF
--- a/src/Transaction/SingleStream.php
+++ b/src/Transaction/SingleStream.php
@@ -36,8 +36,12 @@ final class SingleStream implements TransactionInterface
 
     public function commit()
     {
-        $collection = new WritableEventCollection($this->events);
-        $this->eventstore->writeToStream($this->streamUri, $collection);
+        if (count($this->events)) {
+            $this->eventstore->writeToStream(
+                $this->streamUri,
+                new WritableEventCollection($this->events)
+            );
+        }
 
         $this->resetTransaction();
     }

--- a/tests/unit/Transaction/SingleStreamTest.php
+++ b/tests/unit/Transaction/SingleStreamTest.php
@@ -55,6 +55,19 @@ class SingleStreamTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @covers ::commit
+     * @covers ::push
+     */
+    public function it_should_not_commit_if_there_are_no_events()
+    {
+        $this->eventstore->shouldReceive('writeToStream')->never();
+        $this->transaction->push('streamUri', []);
+
+        $this->transaction->commit();
+    }
+
+    /**
+     * @test
      * @covers ::rollback
      */
     public function it_should_clear_events_on_rollback()


### PR DESCRIPTION
In this PR I've added a check for existence of new events before writing into the stream. This is needed because the eventstore-client library which is used under the hood throws an exception if no events provided to write into the stream.
