### PR TITLE
Add support for metadata

### DIFF
--- a/src/EventStoreRepository.php
+++ b/src/EventStoreRepository.php
@@ -49,7 +49,7 @@ final class EventStoreRepository implements Repository
         $this->streamNameGenerator = $streamNameGenerator;
         $this->eventSerializer     = $eventSerializer;
         $this->transaction         = $transaction;
-        $this->metadataStore = $metadataStore;
+        $this->metadataStore       = $metadataStore;
     }
 
     /**

--- a/src/EventStoreRepositoryFactory.php
+++ b/src/EventStoreRepositoryFactory.php
@@ -21,16 +21,21 @@ final class EventStoreRepositoryFactory implements RepositoryFactory
     /** @var Transaction */
     private $transaction;
 
+    /** @var MetadataStore */
+    private $metadataStore;
+
     public function __construct(
         EventStoreInterface $eventStore,
         StreamNameGenerator $streamNameGenerator = null,
         EventSerializer $eventSerializer = null,
-        Transaction $transaction = null
+        Transaction $transaction = null,
+        MetadataStore $metadataStore = null
     ) {
         $this->streamNameGenerator = $streamNameGenerator ?: new SluggifiedNameAndId();
         $this->eventSerializer = $eventSerializer ?: new FromArrayToArray();
         $this->eventStore = $eventStore;
         $this->transaction = $transaction ?: new None($eventStore);
+        $this->metadataStore = $metadataStore;
     }
 
     /**
@@ -44,7 +49,8 @@ final class EventStoreRepositoryFactory implements RepositoryFactory
             $this->eventSerializer,
             $this->eventStore,
             $this->transaction,
-            $aggregateType
+            $aggregateType,
+            $this->metadataStore
         );
     }
 }

--- a/src/MetadataStore.php
+++ b/src/MetadataStore.php
@@ -1,0 +1,14 @@
+<?php
+namespace PhpInPractice\Matters\Aggregate;
+
+interface MetadataStore
+{
+    /**
+     * Returns the metadata that needs to be registered with this event.
+     *
+     * @param object $event
+     *
+     * @return string[]
+     */
+    public function metadata($event);
+}

--- a/tests/unit/EventStoreRepositoryFactoryTest.php
+++ b/tests/unit/EventStoreRepositoryFactoryTest.php
@@ -12,6 +12,7 @@ use Mockery as m;
  */
 class EventStoreRepositoryFactoryTest extends \PHPUnit_Framework_TestCase
 {
+    private $metadataStore;
     /** @var EventStoreInterface|m\MockInterface */
     private $eventStore;
 
@@ -33,12 +34,14 @@ class EventStoreRepositoryFactoryTest extends \PHPUnit_Framework_TestCase
         $this->streamNameGenerator = m::mock(StreamNameGenerator::class);
         $this->eventSerializer     = m::mock(EventSerializer::class);
         $this->transaction         = m::mock(Transaction::class);
+        $this->metadataStore       = m::mock(MetadataStore::class);
 
         $this->factory = new EventStoreRepositoryFactory(
             $this->eventStore,
             $this->streamNameGenerator,
             $this->eventSerializer,
-            $this->transaction
+            $this->transaction,
+            $this->metadataStore
         );
     }
 
@@ -55,6 +58,7 @@ class EventStoreRepositoryFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeSame($this->eventStore, 'eventstore', $repository);
         $this->assertAttributeSame($this->transaction, 'transaction', $repository);
         $this->assertAttributeSame($this->eventSerializer, 'eventSerializer', $repository);
+        $this->assertAttributeSame($this->metadataStore, 'metadataStore', $repository);
         $this->assertAttributeSame($expected, 'aggregateClassName', $repository);
     }
 }

--- a/tests/unit/EventStoreRepositoryTest.php
+++ b/tests/unit/EventStoreRepositoryTest.php
@@ -16,6 +16,7 @@ use Mockery as m;
  */
 class EventStoreRepositoryTest extends \PHPUnit_Framework_TestCase
 {
+    private $metadataStore;
     /** @var EventStoreInterface|m\MockInterface */
     private $eventStore;
 
@@ -37,13 +38,15 @@ class EventStoreRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->streamNameGenerator = m::mock(StreamNameGenerator::class);
         $this->eventSerializer     = m::mock(EventSerializer::class);
         $this->transaction         = m::mock(Transaction::class);
+        $this->metadataStore       = m::mock(MetadataStore::class);
 
         $this->repository = new EventStoreRepository(
             $this->streamNameGenerator,
             $this->eventSerializer,
             $this->eventStore,
             $this->transaction,
-            AggregateMock::class
+            AggregateMock::class,
+            $this->metadataStore
         );
     }
 
@@ -71,9 +74,13 @@ class EventStoreRepositoryTest extends \PHPUnit_Framework_TestCase
                     $data = $event->toStreamData();
                     $this->assertSame(get_class($exampleEvent), $data['eventType']);
                     $this->assertSame(['id' => 2], $data['data']);
+                    $this->assertSame(['user_id' => 1], $data['metadata']);
                     return true;
                 })
             );
+
+        $this->metadataStore->shouldReceive('metadata')
+            ->with($exampleEvent)->andReturn(['user_id' => 1]);
 
         $this->repository->persist($aggregate);
     }

--- a/tests/unit/EventStoreRepositoryTest.php
+++ b/tests/unit/EventStoreRepositoryTest.php
@@ -16,7 +16,9 @@ use Mockery as m;
  */
 class EventStoreRepositoryTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var MetadataStore|m\MockInterface */
     private $metadataStore;
+
     /** @var EventStoreInterface|m\MockInterface */
     private $eventStore;
 


### PR DESCRIPTION
We add support for adding meta data to events by providing a store where
you can check which event you have received and based on that provide
additional information that you don't want to store with your event.

Metadata handling is optional, and as such this does not break backwards
compatibility.
